### PR TITLE
MAT-21 

### DIFF
--- a/src/features/products/ProductCreateForm.tsx
+++ b/src/features/products/ProductCreateForm.tsx
@@ -7,7 +7,9 @@ import {
   TemplateFormActions,
   TemplateFormSubmitButton,
   TemplateNumberField,
+  TemplateSelectField,
 } from 'src/components/form';
+import { useAllCategoriesQuery } from 'src/api/categoryRepository';
 
 export type CreateProductFormType = {
   name: string;
@@ -15,6 +17,7 @@ export type CreateProductFormType = {
   original_price: number;
   discount_price?: number | null;
   image: string;
+  category_id: number;
 };
 
 const CreateProductSchema: Yup.ObjectSchema<CreateProductFormType> = Yup.object().shape({
@@ -33,6 +36,11 @@ const CreateProductSchema: Yup.ObjectSchema<CreateProductFormType> = Yup.object(
     .positive('Debe ser mayor a 0')
     .max(Yup.ref('original_price'), 'No puede ser mayor al precio original'),
   image: Yup.string().required('La imagen es requerida'),
+  category_id: Yup.number()
+    .typeError('La categoría es requerida')
+    .positive('Debe seleccionar una categoría')
+    .required('La categoría es requerida')
+    .moreThan(0, 'Debe seleccionar una categoría válida'),
 });
 
 const defaultValues: CreateProductFormType = {
@@ -41,6 +49,7 @@ const defaultValues: CreateProductFormType = {
   original_price: 0,
   discount_price: null,
   image: '',
+  category_id: 0,
 };
 
 type Props = {
@@ -53,6 +62,7 @@ export default function ProductCreateForm({ onSubmit }: Props) {
     defaultValues,
     mode: 'onBlur',
   });
+  const { data: categories } = useAllCategoriesQuery();
 
   return (
     <TemplateForm hf={hf} onSubmit={onSubmit}>
@@ -86,6 +96,21 @@ export default function ProductCreateForm({ onSubmit }: Props) {
           <TemplateNumberField<CreateProductFormType>
             {...{ field, fieldState, formState }}
             label="Precio con descuento"
+          />
+        )}
+      />
+      <Controller
+        name="category_id"
+        control={hf.control}
+        render={({ field, fieldState, formState }) => (
+          <TemplateSelectField
+            {...{ field, fieldState, formState }}
+            label="Categoría"
+            placeholder="Seleccionar categoría"
+            options={(categories ?? []).map((c) => ({
+              value: c.id,
+              label: c.name,
+            }))}
           />
         )}
       />

--- a/src/features/products/ProductEditForm.tsx
+++ b/src/features/products/ProductEditForm.tsx
@@ -7,16 +7,19 @@ import {
   TemplateFormSubmitButton,
   TemplateNumberField,
   TemplateTextField,
+  TemplateSelectField,
 } from 'src/components/form';
 
 export type EditProductFormType = {
   name: string;
   original_price: number;
   discount_price: number;
+  category_id: number;
 };
 
 type Props = {
   values: EditProductFormType;
+  categories: { id: number; name: string }[];
   onSubmit: (value: EditProductFormType) => Promise<any>;
 };
 
@@ -31,15 +34,19 @@ const EditProductSchema: Yup.ObjectSchema<EditProductFormType> = Yup.object().sh
     .min(0, 'Debe ser mayor o igual a 0')
     .max(Yup.ref('original_price'), 'No puede ser mayor al precio original')
     .typeError('Debe ser un número'),
+  category_id: Yup.number()
+    .required('La categoría es requerida')
+    .typeError('Seleccione una categoría'),
 });
 
 const defaultValues: EditProductFormType = {
   name: '',
   original_price: 0,
   discount_price: 0,
+  category_id: 0,
 };
 
-export default function ProductEditForm({ values, onSubmit }: Props) {
+export default function ProductEditForm({ values, categories, onSubmit }: Props) {
   const hf = useForm<EditProductFormType>({
     resolver: yupResolver(EditProductSchema),
     defaultValues,
@@ -68,6 +75,21 @@ export default function ProductEditForm({ values, onSubmit }: Props) {
           <TemplateNumberField<EditProductFormType>
             {...{ field, fieldState, formState }}
             label="Precio con descuento"
+          />
+        )}
+      />
+      <Controller
+        name="category_id"
+        control={hf.control}
+        render={({ field, fieldState, formState }) => (
+          <TemplateSelectField
+            {...{ field, fieldState, formState }}
+            label="Categoría"
+            placeholder="Seleccionar categoría"
+            options={categories.map((c) => ({
+              value: c.id,
+              label: c.name,
+            }))}
           />
         )}
       />

--- a/src/features/products/ProductsCreatePage.tsx
+++ b/src/features/products/ProductsCreatePage.tsx
@@ -19,7 +19,7 @@ export const ProductsCreatePage = () => {
     try {
       const payload = {
         ...values,
-        category_id: 1, // Hardcodeado temporalmente para probar el alta de productos
+        category_id: values.category_id,
         images: [{ image_url: values.image }], //agregado para que coincida con el front principal
       };
 

--- a/src/features/products/ProductsDataGrid.tsx
+++ b/src/features/products/ProductsDataGrid.tsx
@@ -78,6 +78,7 @@ export const ProductsDataGrid: React.FC<Props> = ({ data, isLoading, onDelete })
         disableRowSelectionOnClick
         rows={data}
         columns={columns}
+        getRowId={(row) => row.id}
       />
 
       <MenuPopover

--- a/src/features/products/ProductsEditPage.tsx
+++ b/src/features/products/ProductsEditPage.tsx
@@ -7,6 +7,7 @@ import CustomBreadcrumbs from 'src/components/custom-breadcrumbs';
 import { PATHS } from 'src/routes/paths';
 import { useProductQuery, useEditProductMutation } from 'src/api/productRepository';
 import ProductEditForm, { EditProductFormType } from './ProductEditForm';
+import { useAllCategoriesQuery } from 'src/api/categoryRepository';
 
 export const ProductsEditPage = () => {
   const params = useParams<{ id: string }>();
@@ -15,6 +16,7 @@ export const ProductsEditPage = () => {
   const { themeStretch } = useSettingsContext();
 
   const productQuery = useProductQuery(Number(params.id));
+  const categoriesQuery = useAllCategoriesQuery();
   const editProductMutation = useEditProductMutation();
 
   const handleProductUpdate = async (values: EditProductFormType) => {
@@ -36,7 +38,7 @@ export const ProductsEditPage = () => {
         />
 
         <Card sx={{ p: 3 }}>
-          {productQuery.data && (
+          {productQuery.data && categoriesQuery.data && (
             <ProductEditForm
               onSubmit={handleProductUpdate}
               values={{
@@ -44,7 +46,9 @@ export const ProductsEditPage = () => {
                 original_price: productQuery.data.original_price,
                 discount_price:
                   productQuery.data.discount_price ?? productQuery.data.original_price,
+                category_id: productQuery.data.category_id,
               }}
+              categories={categoriesQuery.data}
             />
           )}
         </Card>


### PR DESCRIPTION
Add category selection to product creation and editing forms
- Updated ProductCreateForm and ProductEditForm to include a category selection field using TemplateSelectField.
- Enhanced validation for category_id in both forms to ensure a valid category is selected.
- Modified ProductsCreatePage and ProductsEditPage to handle category_id dynamically instead of hardcoding.
- Ensured ProductsDataGrid correctly identifies rows by their id.